### PR TITLE
Update percy-storybook to @percy/storybook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
       // Build the storybook project
       await exec.exec(`"${npxPath}" build-storybook ${storybookFlags}`, [], execOptions);
       // Run Percy over the build output
-      await exec.exec(`"${npxPath}" percy-storybook ${percyFlags}`, [], execOptions);
+      await exec.exec(`"${npxPath}" @percy/storybook ${percyFlags}`, [], execOptions);
 
       return;
     }


### PR DESCRIPTION
It appears the `percy-storybook` package is now `@percy/storybook`.

Fixes #6 