### PR TITLE
Handles PR number when pull_request_review is the trigger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let customCommand = core.getInput('custom-command');
     let storybookFlags = core.getInput('storybook-flags');
     let workingDir = core.getInput('working-directory');
-    let pullRequestNumber = github.context.payload.number;
+    let pullRequestNumber = github.context.payload.number || github.event.pull_request.number;
     let execOptions = {
       cwd: workingDir,
       windowsVerbatimArguments: true


### PR DESCRIPTION
When `pull_request_review` is the event that triggers a workflow run the GitHub context doesn't contain `payload.number` resulting in the error `##[error]Cannot read property 'replace' of undefined`

Example workflow code:

```
on:
  pull_request_review:
    types: [submitted]
```

Possible resolution: `pull_request_review` contains an event called `pull_request.number` which contains the PR number.