### PR TITLE
fix: Don't error when setting branch name from `pull_request_review` action trigger

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8642,7 +8642,11 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     core.exportVariable('PERCY_BRANCH', prBranch);
     core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
   } else {
-    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+    try {
+      core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+    } catch (err) {
+      console.log(`[percy] Couldn't set branch: ${err}`);
+    }
   }
 }
 
@@ -8652,10 +8656,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let customCommand = core.getInput('custom-command');
     let storybookFlags = core.getInput('storybook-flags');
     let workingDir = core.getInput('working-directory');
-    let pullRequestNumber = github.context.payload.number || github.event.pull_request.number;
+    let pullRequestNumber = github.context.payload.number;
     let execOptions = {
       cwd: workingDir,
-      windowsVerbatimArguments: true
+      windowsVerbatimArguments: true,
     };
 
     // Set the CI builds user agent

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,11 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     core.exportVariable('PERCY_BRANCH', prBranch);
     core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
   } else {
-    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+    try {
+      core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+    } catch (err) {
+      console.log(`[percy] Couldn't set branch: ${err}`);
+    }
   }
 }
 
@@ -24,10 +28,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let customCommand = core.getInput('custom-command');
     let storybookFlags = core.getInput('storybook-flags');
     let workingDir = core.getInput('working-directory');
-    let pullRequestNumber = github.context.payload.number || github.event.pull_request.number;
+    let pullRequestNumber = github.context.payload.number;
     let execOptions = {
       cwd: workingDir,
-      windowsVerbatimArguments: true
+      windowsVerbatimArguments: true,
     };
 
     // Set the CI builds user agent


### PR DESCRIPTION
## What is this?

This is related to #12 & #13. The error that occurs when running workflows triggered off of `pull_request_review` is due to the branch name `ref` being in a different part of the payload vs other workflow triggers. This PR does *not* solve that issue. This PR simply ensures that error does not fail the build.

There will need to be follow up work to search the webhook payload(s) to find the info we need (since it's different across the various triggers). 