### PR TITLE
Use latest versions in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Install
         run: yarn
       - name: Percy Test
-        uses: percy/storybook-action@v0.1.1
+        uses: percy/storybook-action@v0.1.6
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 ```
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: yarn
       - name: Percy Test
-        uses: percy/storybook-action@v0.1.1
+        uses: percy/storybook-action@v0.1.6
         with:
           custom-command: 'yarn storybook:percy'
         env:


### PR DESCRIPTION
So folks like me who want to copy+paste from readmes don't get bit by seeing the error documented in #21